### PR TITLE
Provide build/run helper scripts and default bash command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use the latest Ubuntu LTS image
+FROM ubuntu:latest
+
+# Install required tools
+# - build-essential: tools for compiling C and C++ programs
+# - python3: Python interpreter
+# - python3-pip: Python package manager
+# - neovim: terminal text editor
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        python3 \
+        python3-pip \
+        neovim && \
+    rm -rf /var/lib/apt/lists/* # cleanup package lists to reduce image size
+
+# Default to a bash shell when the container starts
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # Dockerfile
-Template for Dockerfile assisted by Codex
+This repository provides a simple Dockerfile for a development
+environment capable of compiling C/C++ programs and running Python.
+
+### Usage
+
+1. Build the Docker image:
+
+   ```bash
+   ./build.sh [image-name]
+   ```
+
+2. Run a container from the image:
+
+   ```bash
+   ./run.sh [image-name] [container-name]
+   ```
+
+3. Attach to a running container:
+
+   ```bash
+   ./shell.sh [container-name]
+   ```
+
+By default the scripts use `dev-image` for the image name and
+`dev-container` for the container name.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Build the Docker image from the Dockerfile in this directory.
+# Usage: ./build.sh [image-name]
+# Default image name: dev-image
+
+IMAGE_NAME=${1:-dev-image}
+
+docker build -t "$IMAGE_NAME" .

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Run a container from the image built with build.sh.
+# Usage: ./run.sh [image-name] [container-name]
+# Default image name: dev-image
+# Default container name: dev-container
+
+IMAGE_NAME=${1:-dev-image}
+CONTAINER_NAME=${2:-dev-container}
+
+docker run -it --name "$CONTAINER_NAME" "$IMAGE_NAME"

--- a/shell.sh
+++ b/shell.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Open a bash shell inside a running container.
+# Usage: ./shell.sh [container-name]
+# Default container name: dev-container
+
+CONTAINER_NAME=${1:-dev-container}
+
+docker exec -it "$CONTAINER_NAME" /bin/bash


### PR DESCRIPTION
## Summary
- use `bash` as the default command instead of launching nvim
- add helper scripts to build the image, run a container and open a shell
- document the scripts in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68806511cca8832e9ad75e055ad40f52